### PR TITLE
Classpath matching revision for rule import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.project
+.classpath
+.settings/
+target/

--- a/kr-core/src/main/clojure/edu/ucdenver/ccp/kr/rule.clj
+++ b/kr-core/src/main/clojure/edu/ucdenver/ccp/kr/rule.clj
@@ -59,10 +59,12 @@
 
 ;;loads from all the files that match the pattern
 (defn load-rules-from-classpath [pattern]
-  ;;(mapcat read-all-input
   (mapcat all-input
           (remove directory?
-                  (classpath-matching pattern))))
+                  ;; rules are stored in .clj files, so the .clj suffix
+                  ;; is specified as a requirement in the
+                  ;; classpath-matching function
+                  (classpath-matching pattern ".clj"))))
 
   
 

--- a/kr-core/src/main/clojure/edu/ucdenver/ccp/utils.clj
+++ b/kr-core/src/main/clojure/edu/ucdenver/ccp/utils.clj
@@ -116,10 +116,21 @@
            (classpath))))
 
 
-(defn classpath-matching [path-part]
-  (remove (fn [file]
-            (not (.contains (str file) path-part)))
-          (classpath-seq)))
+(defn classpath-matching
+  ([path-part]
+   "Filters all members of the classpath by retaining only those that
+  match path-part."
+   (remove (fn [file]
+             (not (.contains (str file) path-part)))
+           (classpath-seq)))
+  ([path-part suffix]
+   "Filters all members of the classpath by retaining only those that
+  match path-part. The results are further filtered by requiring the
+  suffix on all returned paths to match the specified suffix
+  parameter."
+   (remove (fn [file]
+             (not (.endsWith (str file) suffix)))
+           (classpath-matching path-part))))
 
 
 (defn resource-reader [resource-name]


### PR DESCRIPTION
Revised the classpath-matching function to allow for filtering by file suffix
Rule filtering now mandates .clj suffix

The classpath-matching function is used to extract rule files from the classpath. It
previously included any file in the classpath that matches the input
path. In order to prevent inclusion of rule documentation (e.g. .png
and other files), this function now allows a file suffix to be optionally
specified and used as part of the classpath match.